### PR TITLE
Add table with stats on each file

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -3,6 +3,7 @@ import { exec as childProcessExec } from 'child_process';
 import { markdown } from 'danger';
 import * as util from 'util';
 import BundleChecker from './src/lib/index';
+import { createMarkdownTable } from './src/lib/utils';
 import { IBundleCheckerParams } from './types/bundle-checker-types';
 
 const exec = util.promisify(childProcessExec);
@@ -19,7 +20,10 @@ const exec = util.promisify(childProcessExec);
   };
 
   const checker = new BundleChecker(bundleCheckerParams);
-  const reportText = await checker.compare();
+  const reportRows = createMarkdownTable([
+    ['File', bundleCheckerParams.targetBranch, bundleCheckerParams.currentBranch],
+    ...(await checker.compare())
+  ]);
 
-  markdown(reportText);
+  markdown(reportRows);
 })();

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "scripts": {
     "build": "rm -rf ./build/* && tsc -p ./tsconfig.prod.json",
     "lint:fix": "yarn lint --fix",
-    "lint": "tslint **/*.ts",
+    "lint": "tslint src/**/*.ts",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf ./build && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest"

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -27,7 +27,7 @@ export default class Compare extends Command {
     const { flags } = this.parse(Compare);
     const localFlags = await this.mergeFlagsWithDefaults(flags);
     const checker = new BundleChecker(localFlags);
-    const result = await checker.compare();
+    const result = await checker.compareDeprecated();
     console.log(result);
   }
   private async mergeFlagsWithDefaults(flags: any) {

--- a/src/lib/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/src/lib/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generating markdown tables build a markdown table with the content given 1`] = `
-"| git branch | file size |
-| --- | --- |
-| master️ | js: 356.6kB, css: 0 |
-| develop | js: 376.4kB, css: 0 |"
+"| git branch | base branch | current branch |
+| --- | --- | --- |
+| file1.js | 356.6kB | 320KB |
+| file2.css | 320kB | 330KB |"
 `;

--- a/src/lib/__tests__/index.spec.ts
+++ b/src/lib/__tests__/index.spec.ts
@@ -17,7 +17,7 @@ describe('Bundle Checker', () => {
   jest.setTimeout(TEN_MINUTES);
   test(`Can get bundle size of two branches`, async () => {
     const checker = new BundleChecker(dummyParams);
-    const result = await checker.compare();
+    const result = await checker.compareDeprecated();
     expect(result).toContain('master | ');
   });
 });

--- a/src/lib/__tests__/utils.spec.ts
+++ b/src/lib/__tests__/utils.spec.ts
@@ -1,17 +1,14 @@
-import { ITableReport, ITableRow } from '../../../types/bundle-checker-types';
+import { IFileSizeReport, ITableRow } from '../../../types/bundle-checker-types';
 import {
   createMarkdownTable,
-  getRowsForTotalSizeReport,
+  getFormattedRows,
   groupByFileExtension,
   withDeltaSize
 } from '../utils';
 describe('generating markdown tables', () => {
   it('build a markdown table with the content given', () => {
-    const headers = ['git branch', 'file size'] as ITableRow;
-    const rows = [
-      ['master️', 'js: 356.6kB, css: 0'],
-      ['develop', 'js: 376.4kB, css: 0']
-    ] as ITableRow[];
+    const headers = ['git branch', 'base branch', 'current branch'] as ITableRow;
+    const rows = [['file1.js', '356.6kB', '320KB'], ['file2.css', '320kB', '330KB']] as ITableRow[];
 
     const table = createMarkdownTable([headers, ...rows]);
 
@@ -44,22 +41,20 @@ describe('generating markdown tables', () => {
   });
 
   it('Creates rows for total size report in the expected format', () => {
-    const targetBranchReport: ITableReport = {
+    const targetBranchReport: IFileSizeReport = {
       css: 150,
       js: 1000
     };
-    const currentBranchReport: ITableReport = {
+    const currentBranchReport: IFileSizeReport = {
       jpg: 2000,
       js: 1100
     };
     const expectedFormat: ITableRow[] = [
-      ['.css', '150B', '0B (▼ -150B)'],
-      ['.jpg', '0B', '1.95KB (🔺 +1.95KB)'],
-      ['.js', '1000B', '1.07KB (🔺 +100B)']
+      ['css', '150B', '0B (▼ -150B)'],
+      ['jpg', '0B', '1.95KB (🔺 +1.95KB)'],
+      ['js', '1000B', '1.07KB (🔺 +100B)']
     ];
 
-    expect(getRowsForTotalSizeReport(targetBranchReport, currentBranchReport)).toEqual(
-      expectedFormat
-    );
+    expect(getFormattedRows(targetBranchReport, currentBranchReport)).toEqual(expectedFormat);
   });
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -161,7 +161,7 @@ export default class BundleChecker {
   }
 
   /**
-   * Returns a list of each files that are matched by IBundleCheckerParams.targetFilesPattern
+   * Returns a list of each files (in a single branch) that are matched by IBundleCheckerParams.targetFilesPattern
    */
   private async getFilesSizes(): Promise<IFileSizeReport> {
     this.spinner.start(

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,8 +25,11 @@ export default class BundleChecker {
     this.originalCwd = process.cwd();
   }
 
-  // Refactor this, it is doing too much
-  public async compare(): Promise<IBundleCheckerReport> {
+  /*
+   * Refactor this, it is doing too much
+   * @deprecated This will be deleted soon. Please use `compare` instead
+   */
+  public async compareDeprecated(): Promise<string> {
     let reportRows: ITableRow[];
     const { currentBranch, targetBranch } = this.inputParams;
     try {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import printBytes from 'bytes';
 import { groupBy } from 'ramda';
-import { ITableReport, ITableRow } from '../../types/bundle-checker-types';
+import { IFileSizeReport, ITableRow } from '../../types/bundle-checker-types';
 
 export function withDeltaSize(a: number = 0, b: number = 0): string {
   const icon = b - a > 0 ? `🔺` : `▼`;
@@ -24,11 +24,14 @@ export const groupByFileExtension = (targetedFiles: string[]): { [key: string]: 
     return current.split('.').pop() || 'No extension';
   })(targetedFiles);
 
-export const getRowsForTotalSizeReport = (a: ITableReport, b: ITableReport): ITableRow[] =>
-  Object.keys({ ...a, ...b })
+export const getFormattedRows = (
+  targetBranchReport: IFileSizeReport,
+  currentBranchReport: IFileSizeReport
+): ITableRow[] =>
+  Object.keys({ ...targetBranchReport, ...currentBranchReport })
     .sort()
-    .map(fileExtension => [
-      `.${fileExtension}`,
-      printBytes(a[fileExtension] || 0),
-      withDeltaSize(a[fileExtension], b[fileExtension])
+    .map(fileName => [
+      fileName,
+      printBytes(targetBranchReport[fileName] || 0),
+      withDeltaSize(targetBranchReport[fileName], currentBranchReport[fileName])
     ]);

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,6 @@
 {
   "rulesDirectory": ["tslint-plugin-prettier"],
   "extends": ["tslint:latest", "tslint-config-prettier", "tslint-plugin-prettier"],
-  "linterOptions": {
-    "exclude": ["example"]
-  },
   "rules": {
     "no-console": false,
     "curly": false,

--- a/types/bundle-checker-types.d.ts
+++ b/types/bundle-checker-types.d.ts
@@ -1,4 +1,7 @@
-export type IBundleCheckerReport = string;
+export interface IBundleCheckerReport {
+  currentBranch: IFileSizeReport;
+  targetBranch: IFileSizeReport;
+}
 
 export interface IBundleCheckerParams {
   // The build script that will be run as part of the bundle checker.
@@ -17,10 +20,10 @@ export interface IBundleCheckerParams {
   targetBranch: string;
 }
 
-export interface ITableReport {
+export interface IFileSizeReport {
   [key: string]: number;
 }
 
-export type ITableCell = string;
+export type ITableCell = string | number;
 
-export type ITableRow = [ITableCell, ITableCell, ITableCell?];
+export type ITableRow = [ITableCell, ITableCell, ITableCell];

--- a/types/declarations.d.ts
+++ b/types/declarations.d.ts
@@ -3,5 +3,5 @@ declare module 'size-limit' {
     gzipped: number;
     parsed: number;
   }
-  export default function(files: string[], options?: any): Promise<ISizeLimitResponse>;
+  export default function(files: string[] | string, options?: any): Promise<ISizeLimitResponse>;
 }


### PR DESCRIPTION
We're now displaying a table with stats on each targeted file, as opposed to the totals.

This is the first step towards deleting the old `compare()` function that needed a refactor.
In a second PR, i'll restore the `totals` table, reusing the newly created logic and deleting `compareDeprecated()`