### PR TITLE
Update env vars naming to make it travis-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ The command needs 3 env variable set:
 
 | var                        | Desc                   |
 | -------------------------- | ---------------------- |
-| _TRAVIS_PULL_REQUEST_      | Number of pull request |
-| _TRAVIS_PULL_REQUEST_SLUG_ | _nodejs/node_          |
+| _PULL_REQUEST_NUMBER_      | Number of pull request |
+| _PULL_REQUEST_SLUG_        | e.g. _facebook/react_  |
 | _GITHUB_TOKEN_             | secret to be setup     |
 
-> Travis will obviously provide `TRAVIS_PULL_REQUEST`, `TRAVIS_PULL_REQUEST_SLUG` for you already.
+> If you're working with Travis, no need to setup env variables `PULL_REQUEST_NUMBER` or `PULL_REQUEST_SLUG`. 
+Those are read from `TRAVIS_PULL_REQUEST` and `TRAVIS_PULL_REQUEST_SLUG` automatically.
 
 ## Develop and test locally the CLI
 

--- a/package.json
+++ b/package.json
@@ -103,5 +103,5 @@
     "prepack": "rm -rf ./build && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
-  "version": "0.2.10"
+  "version": "0.2.11"
 }

--- a/src/lib/__tests__/utils.spec.ts
+++ b/src/lib/__tests__/utils.spec.ts
@@ -27,10 +27,10 @@ describe('generating markdown tables', () => {
       'font-italic.123716.woff'
     ];
     const expectedGrouping = {
-      css: ['main.css', 'shared.css'],
-      js: ['main.js', 'shared.js'],
-      png: ['sprite.png'],
-      woff: ['font.woff', 'font-italic.123716.woff']
+      '.css': ['main.css', 'shared.css'],
+      '.js': ['main.js', 'shared.js'],
+      '.png': ['sprite.png'],
+      '.woff': ['font.woff', 'font-italic.123716.woff']
     };
 
     expect(groupFilesByExtension(targetedFiles)).toMatchObject(expectedGrouping);
@@ -43,20 +43,20 @@ describe('generating markdown tables', () => {
 
   it('Creates rows for total size report in the expected format', () => {
     const targetBranchReport: IFileSizeReport = {
-      css: 150,
-      js: 1000,
-      svg: 150
+      '.css': 150,
+      '.js': 1000,
+      '.svg': 150
     };
     const currentBranchReport: IFileSizeReport = {
-      jpg: 2000,
-      js: 1100,
-      svg: 150
+      '.jpg': 2000,
+      '.js': 1100,
+      '.svg': 150
     };
     const expectedFormat: ITableRow[] = [
-      ['jpg', '1.95KB (🔺 +1.95KB)', '0B'],
-      ['js', '1.07KB (🔺 +100B)', '1000B'],
-      ['svg', '150B', '150B'],
-      ['css', '0B (▼ -150B)', '150B']
+      ['.jpg', '1.95KB (🔺 +1.95KB)', '0B'],
+      ['.js', '1.07KB (🔺 +100B)', '1000B'],
+      ['.svg', '150B', '150B'],
+      ['.css', '0B (▼ -150B)', '150B']
     ];
 
     expect(getFormattedRows({ targetBranchReport, currentBranchReport })).toEqual(expectedFormat);
@@ -71,9 +71,9 @@ describe('generating markdown tables', () => {
       'e.jpeg': 2000
     };
     const expectedOutput = {
-      css: 4500,
-      jpeg: 2000,
-      js: 3000
+      '.css': 4500,
+      '.jpeg': 2000,
+      '.js': 3000
     };
 
     expect(squashReportByFileExtension(input)).toMatchObject(expectedOutput);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -109,12 +109,10 @@ export default class BundleChecker {
       `Calculating sizes of files matching: \`${this.inputParams.buildFilesPatterns}\``
     );
     const targetedFiles = await this.getTargetedFiles(this.inputParams.buildFilesPatterns);
-    const fileSizes: number[] = await Promise.all(
-      targetedFiles.map(file => this.safeGetSize([file]))
-    );
+    const fileSizes: number[] = await Promise.all(targetedFiles.map(this.safeGetSize));
     const filePaths = targetedFiles.map(file => file.replace(this.workDir, ''));
     this.spinner.succeed();
-    return zipObj(filePaths, fileSizes);
+    return zipObj(filePaths as ReadonlyArray<string>, fileSizes);
   }
 
   private async getTargetedFiles(regex: string[]): Promise<string[]> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -42,10 +42,7 @@ export function createMarkdownTable([headerRow, ...contentRows]: ITableRow[]): s
   return `${buildHeader(headerRow)}\n` + `${buildRows(contentRows)}`;
 }
 
-export const groupFilesByExtension = (targetedFiles: string[]): { [key: string]: string[] } =>
-  groupBy((current: string) => {
-    return path.extname(current);
-  })(targetedFiles);
+export const groupFilesByExtension = groupBy(path.extname);
 
 export const getFormattedRows = (report: IBundleCheckerReport): ITableRow[] =>
   Object.keys({ ...report.targetBranchReport, ...report.currentBranchReport })
@@ -58,7 +55,7 @@ export const getFormattedRows = (report: IBundleCheckerReport): ITableRow[] =>
         ] as IAbstractTableRow
     )
     .sort(sortByDelta)
-    .map(([fileName, currentBranchSize, targetBranchSize]: any) => [
+    .map(([fileName, currentBranchSize, targetBranchSize]: IAbstractTableRow) => [
       fileName,
       withDeltaSize(targetBranchSize, currentBranchSize),
       printBytes(targetBranchSize)
@@ -69,7 +66,7 @@ export const getFormattedRows = (report: IBundleCheckerReport): ITableRow[] =>
  */
 export const squashReportByFileExtension = (report: IFileSizeReport): IFileSizeReport => {
   const keysGroupedByExtension = Object.keys(
-    groupFilesByExtension(Object.keys(report))
+    groupFilesByExtension(Object.keys(report) as ReadonlyArray<string>)
   ) as ReadonlyArray<string>;
 
   return zipObj(keysGroupedByExtension, keysGroupedByExtension.map(fileExtension =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import Github from '@octokit/rest';
 import printBytes from 'bytes';
+import path from 'path';
 import { groupBy, zipObj } from 'ramda';
 import {
   IAbstractTableRow,
@@ -41,11 +42,9 @@ export function createMarkdownTable([headerRow, ...contentRows]: ITableRow[]): s
   return `${buildHeader(headerRow)}\n` + `${buildRows(contentRows)}`;
 }
 
-export const getFileExtension = (fileName: string) => fileName.split('.').pop() || 'No extension';
-
 export const groupFilesByExtension = (targetedFiles: string[]): { [key: string]: string[] } =>
   groupBy((current: string) => {
-    return getFileExtension(current);
+    return path.extname(current);
   })(targetedFiles);
 
 export const getFormattedRows = (report: IBundleCheckerReport): ITableRow[] =>
@@ -75,7 +74,7 @@ export const squashReportByFileExtension = (report: IFileSizeReport): IFileSizeR
 
   return zipObj(keysGroupedByExtension, keysGroupedByExtension.map(fileExtension =>
     Object.keys(report)
-      .filter(file => getFileExtension(file) === fileExtension)
+      .filter(file => path.extname(file) === fileExtension)
       .reduce((sequence: number, currentFileName) => sequence + report[currentFileName], 0)
   ) as ReadonlyArray<number>);
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,12 +105,15 @@ export async function commentOnPr({
   )}`;
 
   try {
-    const { GITHUB_TOKEN, TRAVIS_PULL_REQUEST, TRAVIS_PULL_REQUEST_SLUG } = process.env as any;
-    const [owner, repo] = TRAVIS_PULL_REQUEST_SLUG.split('/');
+    const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+    const PULL_REQUEST_NUMBER = process.env.TRAVIS_PULL_REQUEST as number;
+    const PULL_REQUEST_SLUG = process.env.TRAVIS_PULL_REQUEST_SLUG;
+
+    const [owner, repo] = PULL_REQUEST_SLUG.split('/');
     const octokit = new Github({ auth: GITHUB_TOKEN });
     const body = `${overviewTable}\n\n${filesBreakDownTable}\n\n${COMMENT_WATERMARK}`;
     const githubParams = {
-      number: TRAVIS_PULL_REQUEST,
+      number: PULL_REQUEST_NUMBER,
       owner,
       repo
     };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,9 +105,12 @@ export async function commentOnPr({
   )}`;
 
   try {
-    const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-    const PULL_REQUEST_NUMBER = process.env.TRAVIS_PULL_REQUEST as number;
-    const PULL_REQUEST_SLUG = process.env.TRAVIS_PULL_REQUEST_SLUG;
+    const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';
+    const PULL_REQUEST_NUMBER = Number(
+      process.env.TRAVIS_PULL_REQUEST || process.env.PULL_REQUEST_NUMBER
+    );
+    const PULL_REQUEST_SLUG =
+      process.env.TRAVIS_PULL_REQUEST_SLUG || process.env.PULL_REQUEST_SLUG || '';
 
     const [owner, repo] = PULL_REQUEST_SLUG.split('/');
     const octokit = new Github({ auth: GITHUB_TOKEN });


### PR DESCRIPTION
- now relying on `PULL_REQUEST_NUMBER` and `PULL_REQUEST_SLUG`
- remove custom file extension utility, relying on `path.extname` instead
- points-free refactors to some helpers

closes #46 