### PR TITLE
Output format of build should be `es6` to work on node8

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,5 @@
     "prepack": "rm -rf ./build && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,6 +13,7 @@ import {
 } from '../../types/bundle-checker-types';
 import { normalizeSlugsInFileNames } from './utils';
 const exec = util.promisify(childProcessExec);
+const { error } = console;
 
 export default class BundleChecker {
   private workDir = '';
@@ -52,9 +53,9 @@ export default class BundleChecker {
         currentBranchReport,
         targetBranchReport
       };
-    } catch (error) {
-      this.spinner.fail(error);
-      error(error);
+    } catch (e) {
+      this.spinner.fail(e);
+      error(e);
     }
     await this.destroy();
     return report;
@@ -119,7 +120,7 @@ export default class BundleChecker {
   private async getTargetedFiles(regex: string[]): Promise<string[]> {
     try {
       return await globby(regex.map(item => path.resolve(item)));
-    } catch (error) {
+    } catch {
       return [];
     }
   }
@@ -134,7 +135,7 @@ export default class BundleChecker {
     try {
       // Todo: add `gzip: false` in the options, since we're only intereseted in parsed size
       return (await getSize(files, { webpack: false })).parsed;
-    } catch (error) {
+    } catch {
       return 0;
     }
   }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -111,15 +111,19 @@ export default class BundleChecker {
       `Calculating sizes of files matching: \`${this.inputParams.buildFilesPatterns}\``
     );
     const targetedFiles = await this.getTargetedFiles(this.inputParams.buildFilesPatterns);
-    const fileSizes: number[] = await Promise.all(targetedFiles.map(this.safeGetSize));
-    const filePaths = targetedFiles.map(file => file.replace(this.workDir, ''));
+    const fileSizes = (await Promise.all(targetedFiles.map(this.safeGetSize))) as ReadonlyArray<
+      number
+    >;
+    const filePaths = targetedFiles.map(file => file.replace(this.workDir, '')) as ReadonlyArray<
+      string
+    >;
     this.spinner.succeed();
-    return zipObj(filePaths as ReadonlyArray<string>, fileSizes);
+    return zipObj(filePaths, fileSizes);
   }
 
   private async getTargetedFiles(regex: string[]): Promise<string[]> {
     try {
-      return await globby(regex.map(item => path.resolve(item)));
+      return await globby(regex.map(item => path.resolve(item)) as ReadonlyArray<string>);
     } catch {
       return [];
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "outDir": "build",
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "es2015"
   },
   "include": ["src", "types"]
 }


### PR DESCRIPTION
I've reverted a hotfix merged in on Friday, which attempted to work around a missing exception identifier which caused problemns on node 8.

Details here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#The_exception_identifier

Also, I've tweaked the types needed for `globby` and `zipObj` (both need a `ReadonlyArray<T>`