### PR TITLE
Re-use build script in prepack, remove lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "tslint src/**/*.ts",
     "postpack": "rm -f oclif.manifest.json",
-    "prepack": "rm -rf ./build && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "yarn build && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
   "version": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   },
   "scripts": {
     "build": "rm -rf ./build/* && tsc -p ./tsconfig.prod.json",
-    "lint:fix": "yarn lint --fix",
     "lint": "tslint src/**/*.ts",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif-dev manifest && oclif-dev readme",


### PR DESCRIPTION
- Prepack script used to be run with a `-b` flag but I think it could be redundant.
- `yarn lint:fix` is equivalent to `yarn lint --fix` so no real benefit there
