### PR TITLE
Use `npm ci` as default install script, with `npm install` fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,5 @@
     "prepack": "rm -rf ./build && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -23,7 +23,10 @@ export default class Compare extends Command {
     }),
     gitRepository: OclifFlags.string({ description: '[default: current git repo] gitRepository' }),
     help: OclifFlags.help({ char: 'h' }),
-    installScript: OclifFlags.string({ description: 'installScript', default: 'npm install' }),
+    installScript: OclifFlags.string({
+      default: 'npm ci || npm install',
+      description: 'installScript'
+    }),
     prComment: OclifFlags.boolean({ description: 'Comment on PR', default: false }),
     targetBranch: OclifFlags.string({ description: 'targetBranch', default: 'master' })
   };


### PR DESCRIPTION
`npm ci` is [way faster than `npm install`](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable).

We still need a `npm install` fallback as:
- `ci` depends on package-lock.json to be there (can't rely on that)
- `npm ci` is not available in node v8