### PR TITLE
add external console.table

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@oclif/plugin-help": "^2",
     "@octokit/rest": "16.23.4",
     "bytes": "^3.1.0",
+    "console.table": "^0.10.0",
     "globby": "^9.2.0",
     "ora": "^3.3.0",
     "ramda": "0.26.1",

--- a/package.json
+++ b/package.json
@@ -103,5 +103,5 @@
     "prepack": "yarn build && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,6 +11,7 @@ import {
   IPrintableReport,
   ITableRow
 } from '../../types/bundle-checker-types';
+import consoleTable from 'console.table';
 
 const SHARED_TABLE_VALUES = {
   FILES_BREAKDOWN_TITLE: 'All targeted files',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import Github from '@octokit/rest';
 import printBytes from 'bytes';
+import 'console.table';
 import path from 'path';
 import { groupBy, replace, zipObj } from 'ramda';
 import {
@@ -11,7 +12,6 @@ import {
   IPrintableReport,
   ITableRow
 } from '../../types/bundle-checker-types';
-import consoleTable from 'console.table';
 
 const SHARED_TABLE_VALUES = {
   FILES_BREAKDOWN_TITLE: 'All targeted files',

--- a/types/declarations.d.ts
+++ b/types/declarations.d.ts
@@ -5,3 +5,8 @@ declare module 'size-limit' {
   }
   export default function(files: string[] | string, options?: any): Promise<ISizeLimitResponse>;
 }
+
+// A polyfill for node v8 who doesn't support console.table
+declare module 'console.table' {
+  export default function(): undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 
 console.table@^0.10.0:
   version "0.10.0"
-  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/console.table/-/console.table-0.10.0.tgz#0917025588875befd70cf2eff4bef2c6e2d75d04"
+  resolved "https://registry.yarnpkg.com/console.table/-/console.table-0.10.0.tgz#0917025588875befd70cf2eff4bef2c6e2d75d04"
   integrity sha1-CRcCVYiHW+/XDPLv9L7yxuLXXQQ=
   dependencies:
     easy-table "1.1.0"
@@ -2396,7 +2396,7 @@ duplexify@^3.4.2, duplexify@^3.6.0:
 
 easy-table@1.1.0:
   version "1.1.0"
-  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/easy-table/-/easy-table-1.1.0.tgz#86f9ab4c102f0371b7297b92a651d5824bc8cb73"
+  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.1.0.tgz#86f9ab4c102f0371b7297b92a651d5824bc8cb73"
   integrity sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=
   optionalDependencies:
     wcwidth ">=1.0.1"
@@ -7713,7 +7713,7 @@ watchpack@^1.5.0:
 
 wcwidth@>=1.0.1, wcwidth@^1.0.1:
   version "1.0.1"
-  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,13 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+console.table@^0.10.0:
+  version "0.10.0"
+  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/console.table/-/console.table-0.10.0.tgz#0917025588875befd70cf2eff4bef2c6e2d75d04"
+  integrity sha1-CRcCVYiHW+/XDPLv9L7yxuLXXQQ=
+  dependencies:
+    easy-table "1.1.0"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -2386,6 +2393,13 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+easy-table@1.1.0:
+  version "1.1.0"
+  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/easy-table/-/easy-table-1.1.0.tgz#86f9ab4c102f0371b7297b92a651d5824bc8cb73"
+  integrity sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=
+  optionalDependencies:
+    wcwidth ">=1.0.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -7697,9 +7711,9 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-wcwidth@^1.0.1:
+wcwidth@>=1.0.1, wcwidth@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  resolved "https://hbc.jfrog.io/hbc/api/npm/hbc-virt-npm/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"


### PR DESCRIPTION
- added a non-native version of console.table to enable use of the bundle-checker in repos where the version of node prevents console.table from working (https://github.com/bahmutov/console.table)

![image](https://user-images.githubusercontent.com/15316004/60188118-c4c04b00-97fc-11e9-8060-b37d54d2f1ee.png)
