### PR TITLE
Replace every filename slug with `[...]` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,5 @@
     "prepack": "yarn build && oclif-dev manifest && oclif-dev readme",
     "test": "jest"
   },
-  "version": "1.4.0"
+  "version": "1.5.0"
 }

--- a/src/lib/__tests__/utils.spec.ts
+++ b/src/lib/__tests__/utils.spec.ts
@@ -92,14 +92,16 @@ describe('generating markdown tables', () => {
       '/build/lib/1.zf87zlkx.3gaqd329.js': 187,
       '/build/lib/utils.3gaqd329.css': 3037,
       '/build/z/nohash.js': 150,
-      '/build/z/slugs.another.123123123.js': 300
+      '/build/z/slugs.another.123123123.js': 300,
+      '/static/js/utils.a7jh8iuk.chunk.js': 867
     };
     const expectedOutput = {
       '/build/commands/a.[…].js': 2550,
       '/build/lib/1.[…].[…].js': 187,
       '/build/lib/utils.[…].css': 3037,
       '/build/z/nohash.js': 150,
-      '/build/z/slugs.[…].[…].js': 300
+      '/build/z/slugs.[…].[…].js': 300,
+      '/static/js/utils.[…].chunk.js': 867
     };
 
     expect(normalizeSlugsInFileNames(input)).toMatchObject(expectedOutput);

--- a/src/lib/__tests__/utils.spec.ts
+++ b/src/lib/__tests__/utils.spec.ts
@@ -86,20 +86,35 @@ describe('generating markdown tables', () => {
     expect(squashReportByFileExtension(input)).toMatchObject(expectedOutput);
   });
 
-  it('Is able to replace an ellipsis to the second-to-last slug of a file name, unless its `.min`', () => {
+  it('Is able to replace an ellipsis to each dot-separated slug', () => {
     const input = {
       '/build/commands/a.1fasd123.js': 2550,
-      '/build/lib/utils.3gaqd329.js': 3037,
+      '/build/lib/1.zf87zlkx.3gaqd329.js': 187,
+      '/build/lib/utils.3gaqd329.css': 3037,
       '/build/z/nohash.js': 150,
-      '/build/z/shared.min.js': 300,
       '/build/z/slugs.another.123123123.js': 300
     };
     const expectedOutput = {
       '/build/commands/a.[…].js': 2550,
-      '/build/lib/utils.[…].js': 3037,
+      '/build/lib/1.[…].[…].js': 187,
+      '/build/lib/utils.[…].css': 3037,
       '/build/z/nohash.js': 150,
+      '/build/z/slugs.[…].[…].js': 300
+    };
+
+    expect(normalizeSlugsInFileNames(input)).toMatchObject(expectedOutput);
+  });
+
+  it('Leaves `.min` and `.MIN` unaltered in the final report', () => {
+    const input = {
       '/build/z/shared.min.js': 300,
-      '/build/z/slugs.another.[…].js': 300
+      '/build/z/utils.zj67zjkx.MIN.zf87zlkl.js': 310,
+      'app.min.ajh76yu.js': 415
+    };
+    const expectedOutput = {
+      '/build/z/shared.min.js': 300,
+      '/build/z/utils.[…].MIN.[…].js': 310,
+      'app.min.[…].js': 415
     };
 
     expect(normalizeSlugsInFileNames(input)).toMatchObject(expectedOutput);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -116,6 +116,7 @@ export const normalizeSlugsInFileNames = (report: IFileSizeReport): IFileSizeRep
           case index === 0:
           case index === fileNameSlugs.length - 1:
           case slug.toLowerCase() === 'min':
+          case slug.toLowerCase() === 'chunk':
             return slug;
           default:
             return '[…]';


### PR DESCRIPTION
All filename slugs (apart from `.min` and `.chunk`, appearing anywhere in the filename) will be replaced with `[...]`

Please refer to this test for a visual clue of what that means:
https://github.com/rbelling/bundle-checker/compare/feature/group-chunks?expand=1#diff-a85ab1aee96bb0ac2301c1599e632127R89-R102


